### PR TITLE
Remove www. if present from setCookieDomain of JS tracking code

### DIFF
--- a/core/Tracker/TrackerCodeGenerator.php
+++ b/core/Tracker/TrackerCodeGenerator.php
@@ -24,11 +24,10 @@ class TrackerCodeGenerator
 {
     /**
      * whether matomo.js|php should be forced over piwik.js|php
-     * @var bool
      */
-    private $shouldForceMatomoEndpoint = false;
+    private bool $shouldForceMatomoEndpoint = false;
 
-    public function forceMatomoEndpoint()
+    public function forceMatomoEndpoint(): void
     {
         $this->shouldForceMatomoEndpoint = true;
     }
@@ -67,7 +66,7 @@ class TrackerCodeGenerator
         $crossDomain = false,
         $excludedQueryParams = false,
         $excludedReferrers = []
-    ) {
+    ): string {
         if (substr($piwikUrl, 0, 4) !== 'http') {
             $piwikUrl = 'http://' . $piwikUrl;
         }
@@ -230,7 +229,7 @@ class TrackerCodeGenerator
         return $jsCode;
     }
 
-    public function getJsTrackerEndpoint()
+    public function getJsTrackerEndpoint(): string
     {
         $name = 'matomo.js';
         if ($this->shouldPreferPiwikEndpoint()) {
@@ -239,7 +238,7 @@ class TrackerCodeGenerator
         return $name;
     }
 
-    public function getPhpTrackerEndpoint()
+    public function getPhpTrackerEndpoint(): string
     {
         $name = 'matomo.php';
         if ($this->shouldPreferPiwikEndpoint()) {
@@ -248,7 +247,7 @@ class TrackerCodeGenerator
         return $name;
     }
 
-    public function shouldPreferPiwikEndpoint()
+    public function shouldPreferPiwikEndpoint(): string
     {
         if ($this->shouldForceMatomoEndpoint) {
             return false;
@@ -258,7 +257,7 @@ class TrackerCodeGenerator
         return DbHelper::wasMatomoInstalledBeforeVersion('3.7.0-b1');
     }
 
-    private function getJavascriptTagOptions($idSite, $mergeSubdomains, $mergeAliasUrls)
+    private function getJavascriptTagOptions($idSite, $mergeSubdomains, $mergeAliasUrls): string
     {
         try {
             $websiteUrls = APISitesManager::getInstance()->getSiteUrlsFromId($idSite);
@@ -316,7 +315,7 @@ class TrackerCodeGenerator
      * @param string $jsTrackingCode JS tracking code as returned from the generate() function.
      * @return string
      */
-    public static function stripTags($jsTrackingCode)
+    public static function stripTags($jsTrackingCode): string
     {
         // Strip off open and close <script> tag and comments so that JS will be displayed in ALL mail clients
         return trim(strip_tags(html_entity_decode($jsTrackingCode)));

--- a/core/Tracker/TrackerCodeGenerator.php
+++ b/core/Tracker/TrackerCodeGenerator.php
@@ -267,6 +267,7 @@ class TrackerCodeGenerator
         } catch (\Exception $e) {
             return '';
         }
+
         // We need to parse_url to isolate hosts
         $websiteHosts = array();
         $firstHost = null;
@@ -296,13 +297,18 @@ class TrackerCodeGenerator
         }
         $options = '';
         if ($mergeSubdomains && !empty($firstHost)) {
-            $options .= '  _paq.push(["setCookieDomain", "*.' . $firstHost . '"]);' . "\n";
+            $options .= '  _paq.push(["setCookieDomain", "*.' . $this->removeWwwSubdomainIfPresent($firstHost) . '"]);' . "\n";
         }
         if ($mergeAliasUrls && !empty($websiteHosts)) {
             $urls = '["*.' . implode('","*.', $websiteHosts) . '"]';
             $options .= '  _paq.push(["setDomains", ' . $urls . ']);' . "\n";
         }
         return $options;
+    }
+
+    private function removeWwwSubdomainIfPresent(string $urlHost): string
+    {
+        return ltrim($urlHost, 'www.');
     }
 
     /**

--- a/core/Tracker/TrackerCodeGenerator.php
+++ b/core/Tracker/TrackerCodeGenerator.php
@@ -68,8 +68,6 @@ class TrackerCodeGenerator
         $excludedQueryParams = false,
         $excludedReferrers = []
     ) {
-        // changes made to this code should be mirrored in plugins/CoreAdminHome/javascripts/jsTrackingGenerator.js var generateJsCode
-
         if (substr($piwikUrl, 0, 4) !== 'http') {
             $piwikUrl = 'http://' . $piwikUrl;
         }


### PR DESCRIPTION
When the first host has a `www` sub domain this strips it out when generating the `setCookieDomain` for the JS tracking code.

Also a very small bit of house keeping 🧹 .

If I had more time for this the next steps would be:

- Refactor `TrackerCodeGenerator.php` and extract all the complexity into smaller classes, with names with intent so it's a lot easier to follow.
- First thing would be to generate the tracking code (`_paq.push`), using value objects in PHP and then creating a DTO or a view to convert into the javascript format required. 
- Remove the static class references to make the class unit testable.


